### PR TITLE
unicode/ascii readme error in himl 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-with open('README.md') as f:
+with open('README.md', encoding="utf-8") as f:
     _readme = f.read()
 
 _mydir = os.path.abspath(os.path.dirname(sys.argv[0]))


### PR DESCRIPTION
Fixes unicode/ascii problem:

```
[root@74e80f68de54 /]# pip3.6 install himl
Collecting himl
  Downloading https://files.pythonhosted.org/packages/7b/a4/c414ca89cbd620d6943df55709bf36f420454161cb95ba33bcdac195cefd/himl-0.4.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-ww55mnxx/himl/setup.py", line 10, in <module>
        _readme = f.read()
      File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1941: ordinal not in range(128)
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-ww55mnxx/himl/
```