### PR TITLE
Allow AWS_PROFILE not set

### DIFF
--- a/himl/secret_resolvers.py
+++ b/himl/secret_resolvers.py
@@ -36,9 +36,7 @@ class SSMSecretResolver(SecretResolver):
 
     def resolve(self, secret_type, secret_params):
         aws_profile = secret_params.get("aws_profile", self.default_aws_profile)
-        if not aws_profile:
-            raise Exception("Could not find the aws_profile in the secret params for SSM secret: {}".format(secret_params))
-
+        
         path = self.get_param_or_exception("path", secret_params)
         region_name = secret_params.get("region_name", "us-east-1")
         ssm = SimpleSSM(aws_profile, region_name)

--- a/himl/simplessm.py
+++ b/himl/simplessm.py
@@ -34,11 +34,13 @@ class SimpleSSM(object):
             self.release_ssm_client()
 
     def get_ssm_client(self):
-        os.environ['AWS_PROFILE'] = self.aws_profile
+        if self.aws_profile:
+            os.environ['AWS_PROFILE'] = self.aws_profile
         return boto3.client('ssm', region_name=self.region_name)
 
     def release_ssm_client(self):
         if self.initial_aws_profile is None:
-            del os.environ['AWS_PROFILE']
+            if self.aws_profile:
+                del os.environ['AWS_PROFILE']
         else:
             os.environ['AWS_PROFILE'] = self.initial_aws_profile


### PR DESCRIPTION
in SSM, if we don't set any AWS_PROFILE, it will trigger error. In some environment, we don't have any aws profile set, we had to skip the none check to allow SSM to work.

After this fix, our program can be work in AWS EKS.