### PR TITLE
Support exclude key on interpolation for himl

### DIFF
--- a/examples/complex/env=dev/region=us-east-1/cluster=cluster1/cluster.yaml
+++ b/examples/complex/env=dev/region=us-east-1/cluster=cluster1/cluster.yaml
@@ -1,2 +1,21 @@
 cluster:
   name: cluster1
+  testkey: |-
+    # Set to true to log user information returned from LDAP
+      verbose_logging = true
+
+      [[servers]]
+      # Ldap server host
+      host = "someaddress"
+
+      # Default port is 389 or 636 if use_ssl = true
+      port = 389
+
+      start_tls = true
+
+  skipInterpolation_key: "{{`this is a {{ value }} that should not be interpolated`}}"
+  skipInterpolation_dict:
+    skipInterpolation_key: "{{`this is a {{ value }} that should not be interpolated`}}"
+  skipInterpolation_list:
+    - "{{`this is a {{ value }} that should not be interpolated`}}"
+

--- a/himl/interpolation.py
+++ b/himl/interpolation.py
@@ -15,7 +15,8 @@ from .python_compat import iteritems, string_types, primitive_types
 
 
 def is_interpolation(value):
-    return isinstance(value, string_types) and '{{' in value and '}}' in value
+    return isinstance(value, string_types) and '{{' in value and '}}' in value \
+                                           and '{{`' not in value and '`}}' not in value
 
 
 def is_full_interpolation(value):

--- a/himl/interpolation.py
+++ b/himl/interpolation.py
@@ -251,7 +251,7 @@ class FullBlobInjector(object):
 
     @staticmethod
     def get_value_from_escaping(line):
-        # remove {{ and }}
+        # remove {{` and `}}
         line = line[3:-3]
 
         return line


### PR DESCRIPTION
Added support for escaping values where needed, similar to go templating format

```yaml
  skipInterpolationKey: "{{` somevalues `}}"
``` 

This PR intends to solve the discussion from #16 .