### PR TITLE
Small optimization: do not call generator.output_data

### DIFF
--- a/himl/config_generator.py
+++ b/himl/config_generator.py
@@ -85,14 +85,15 @@ class ConfigProcessor(object):
 
         generator.clean_escape_characters()
 
-        formatted_data = generator.output_data(data, output_format)
+        if print_data or output_file:
+            formatted_data = generator.output_data(data, output_format)
 
-        if print_data:
-            print(formatted_data)
+            if print_data:
+                print(formatted_data)
 
-        if output_file:
-            with open(output_file, 'w') as f:
-                f.write(formatted_data)
+            if output_file:
+                with open(output_file, 'w') as f:
+                    f.write(formatted_data)
 
         return data
 


### PR DESCRIPTION
You don't need to call the `generator.output_data` in case when `print_data` and `output_file` are not true.