### PR TITLE
fix: dump computed yaml strings with pipe style

### DIFF
--- a/himl/config_generator.py
+++ b/himl/config_generator.py
@@ -144,10 +144,17 @@ class ConfigGenerator(object):
         Dumper.add_representer(OrderedDict, dict_representer)
         Loader.add_constructor(_mapping_tag, dict_constructor)
 
-        Dumper.add_representer(str, SafeRepresenter.represent_str)
+        def str_representer_pipestyle(dumper, data):
+            style = '|' if '\n' in data else None
+            return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=style)
+        Dumper.add_representer(str, str_representer_pipestyle)
 
         if not PY3:
-            Dumper.add_representer(unicode, SafeRepresenter.represent_unicode)
+            def unicode_representer_pipestyle(dumper, data):
+                style = u'|' if u'\n' in data else None
+                return dumper.represent_scalar(u'tag:yaml.org,2002:str', data, style=style)
+            Dumper.add_representer(unicode, unicode_representer_pipestyle)
+
         return Dumper
 
     @staticmethod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Switch yaml string representation to pipe style for computed values (eg: vault).
<!--- Describe your changes in detail -->

## Related Issue

Fixes #50 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This changes ugly multi line strings from quoted to pipe style

```
before: 'multiline

  string

  end'
```

```
after: |
  string
  end
``` 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
