### PR TITLE
Fixed config-merger script to override SafeLoader to match HIML's YAML loader

### DIFF
--- a/himl/config_merger.py
+++ b/himl/config_merger.py
@@ -158,8 +158,8 @@ def run(args=None):
     # load the !include tag
     Loader.add_constructor('!include', Loader.include)
 
-    # override the Yaml FullLoader with our custom loader
-    yaml.FullLoader = Loader
+    # override the Yaml SafeLoader with our custom loader
+    yaml.SafeLoader = Loader
 
     # extract the list of absolute paths for leaf directories
     dirs = get_leaf_directories(opts.path, opts.leaf_directories)


### PR DESCRIPTION
Fixed the config-merger YAML loader overwrite to match the ConfigGenerator one.
## Description

- Modified from FullLoader to SafeLoader overwrite

## Related Issue

If using the custom "!include" tag, the config-merger script would fail as HIML's ConfigGenerator class uses the SafeLoader as of #28 


## How Has This Been Tested?

Running the config-merger script.


## Types of changes


- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
