### PR TITLE
Added env variable support for himl

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,11 @@ remote_states:
 endpoint: "{{outputs.cluster_composition.output.value.redis_endpoint}}"
 ```
 
+### Merge with env variables
+```yaml
+kubeconfig_location: {{env(KUBECONFIG)}}
+```
+
 
 ## himl config merger
 

--- a/examples/complex/env=dev/region=us-west-2/cluster=cluster1/cluster.yaml
+++ b/examples/complex/env=dev/region=us-west-2/cluster=cluster1/cluster.yaml
@@ -1,1 +1,2 @@
 cluster: cluster1
+home: {{env(HOME)}}

--- a/himl/inject_env.py
+++ b/himl/inject_env.py
@@ -1,0 +1,50 @@
+# Copyright 2021 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+from os import getenv
+
+
+class EnvVarInjector(object):
+    """
+    Resolve variables in the form:
+    {{env(HOME)}}
+    """
+
+    def __init__(self):
+        return
+
+    def is_interpolation(self, value):
+        return value.startswith('{{') and value.endswith('}}')
+
+    def inject_env_var(self, line):
+        """
+        Check if value is an interpolation and try to resolve it.
+        """
+        if not self.is_interpolation(line):
+            return line
+
+        # remove {{ and }}
+        updated_line = line[2:-2]
+
+        # check supported function to ensure the proper format is used
+        if not self.check_supported_function(updated_line):
+            return line
+
+        # remove env( and ) to extract the env Variable
+        updated_line = updated_line[4:-1]
+
+        # If env variable is missing or not set, the output will be None
+        return getenv(updated_line)
+
+    def check_supported_function(self, value):
+        return value.startswith('env(') and value.endswith(')')
+
+    def split_function_items(self, line):
+        line.split()

--- a/himl/inject_env.py
+++ b/himl/inject_env.py
@@ -34,7 +34,7 @@ class EnvVarInjector(object):
         updated_line = line[2:-2]
 
         # check supported function to ensure the proper format is used
-        if not self.check_supported_function(updated_line):
+        if not self.is_env_interpolation(updated_line):
             return line
 
         # remove env( and ) to extract the env Variable
@@ -43,8 +43,5 @@ class EnvVarInjector(object):
         # If env variable is missing or not set, the output will be None
         return getenv(updated_line)
 
-    def check_supported_function(self, value):
+    def is_env_interpolation(self, value):
         return value.startswith('env(') and value.endswith(')')
-
-    def split_function_items(self, line):
-        line.split()

--- a/himl/interpolation.py
+++ b/himl/interpolation.py
@@ -10,6 +10,7 @@
 
 import re
 
+from .inject_env import EnvVarInjector
 from .inject_secrets import SecretInjector
 from .python_compat import iteritems, string_types, primitive_types
 
@@ -80,6 +81,14 @@ class SecretResolver(object):
         secrets_resolver = SecretsInterpolationResolver(injector)
         secrets_resolver.resolve_interpolations(data)
 
+        return data
+
+
+class EnvVarResolver(object):
+    def resolve_env_vars(self, data):
+        injector = EnvVarInjector()
+        env_resolver = EnvVarInterpolationsResolver(injector)
+        env_resolver.resolve_interpolations(data)
         return data
 
 
@@ -166,6 +175,15 @@ class SecretsInterpolationResolver(AbstractInterpolationResolver):
 
     def do_resolve_interpolation(self, line):
         return self.secrets_injector.inject_secret(line)
+
+
+class EnvVarInterpolationsResolver(AbstractInterpolationResolver):
+    def __init__(self, env_vars_injector):
+        AbstractInterpolationResolver.__init__(self)
+        self.env_vars_injector = env_vars_injector
+
+    def do_resolve_interpolation(self, line):
+        return self.env_vars_injector.inject_env_var(line)
 
 
 class InterpolationValidator(DictIterator):


### PR DESCRIPTION
This PR is meant to bring support to Himl for including environment variables when interpolating.

## Description

Added support for HIML to use env variables when interpolating the hierarchy.

## Related Issue

Resolves #52 

## Motivation and Context

See description. Also can be used to include build-time variables in a HIML structure.

## How Has This Been Tested?

Tested out by adding a field in one of the examples with
```yaml
test: {{env(KUBECONFIG)}}
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
