### PR TITLE
Fix missing required args for merging values from dynamic data

### DIFF
--- a/himl/config_generator.py
+++ b/himl/config_generator.py
@@ -276,7 +276,8 @@ class ConfigGenerator(object):
         if "remote_states" in self.generated_data:
             state_files = self.generated_data["remote_states"]
             remote_states = remote_state_retriever.get_dynamic_data(state_files)
-            self.merge_value(self.generated_data, remote_states)
+            self.merge_value(self.generated_data, remote_states, self.type_strategies, self.fallback_strategies,
+                             self.type_conflict_strategies)
 
     def resolve_interpolations(self):
         resolver = InterpolationResolver()


### PR DESCRIPTION
## Description

Add missing required args for merging values from dynamic data

## Related Issue
Fixes https://github.com/adobe/himl/issues/111

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
