### PR TITLE
Removes ability to sort the yaml config keys

### DIFF
--- a/himl/config_generator.py
+++ b/himl/config_generator.py
@@ -263,7 +263,7 @@ class ConfigGenerator(object):
         return values
 
     def output_yaml_data(self, data):
-        return yaml.dump(data, Dumper=ConfigGenerator.yaml_dumper(), default_flow_style=False, width=200)
+        return yaml.dump(data, Dumper=ConfigGenerator.yaml_dumper(), default_flow_style=False, width=200, sort_keys=False)
 
     def yaml_to_json(self, yaml_data):
         return json.dumps(yaml.load(yaml_data, Loader=yaml.SafeLoader), indent=4)


### PR DESCRIPTION
## Description
Removes ability to sort the yaml config keys in the generated data while the print_data happens or while dumping to output file.
As shown in help(yaml.Dumper), sort_keys defaults to True.
