### PR TITLE
Allow ability to target specific files

### DIFF
--- a/himl/config_generator.py
+++ b/himl/config_generator.py
@@ -62,8 +62,8 @@ class ConfigProcessor(object):
                                         output_format, print_data, output_file, skip_interpolations,
                                         skip_interpolation_validation, skip_secrets, formatted_return=format_return)
 
-    def process_file(self, base_path,
-                     path,
+    def process_file(self, base_file_path,
+                     target_file_path,
                      cwd=None,
                      filters=(),
                      exclude_keys=(),
@@ -82,13 +82,13 @@ class ConfigProcessor(object):
                      format_return=False):
         """
         Process a file instead of walking through directory
-        :param base_path: Path to base/default YAML file
-        :param path: Path to YAML file that will be applied on top of base_path
+        :param base_file_path: Path to base/default YAML file
+        :param target_file_path: Path to YAML file that will be applied on top of base_path
         :param format_return: Return formatted string instead of OrderedDict
         """
 
-        path = self.get_relative_path(path)
-        base_path = self.get_relative_path(base_path)
+        target_file_path = self.get_relative_path(target_file_path)
+        base_file_path = self.get_relative_path(base_file_path)
 
         if skip_interpolations or skip_secrets:
             skip_interpolation_validation = True
@@ -96,9 +96,9 @@ class ConfigProcessor(object):
         if cwd is None:
             cwd = os.getcwd()
 
-        generator = ConfigGenerator(cwd, base_path, multi_line_string, type_strategies, fallback_strategies,
+        generator = ConfigGenerator(cwd, base_file_path, multi_line_string, type_strategies, fallback_strategies,
                                     type_conflict_strategies, skip_hierarchy_generation=True)
-        generator.process_file(path)
+        generator.process_file(target_file_path)
 
         return self.finalize_generation(generator, filters, exclude_keys, enclosing_key, remove_enclosing_key,
                                         output_format, print_data, output_file, skip_interpolations,


### PR DESCRIPTION
Instead of walking through directories, allow consumers to pick a specific base file and a target file to apply onto. 

## Description

Add `process_file` function that allows the consumer to specify the `base_file_path` and a `target_file_path` which will be applied on top of the base file.

Adds `format_return` kwarg option which formats the output for either printing or returning.

## Related Issue

https://github.com/adobe/himl/issues/124

## Motivation and Context

I do not want to use the same directory pattern as intended. I want to have my own directory structure and have a default template YAML and an override YAML which applies on top of the default.

## How Has This Been Tested?

Tested locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I do not know how to run the tests
