### PR TITLE
add sops as a secret reslover

### DIFF
--- a/examples/secrets/default.yaml
+++ b/examples/secrets/default.yaml
@@ -1,3 +1,4 @@
 ---
 secret_path_v2: "{{vault.path(/kv2_secret)}}"
 secret_key_v2: "{{vault.key(/kv2_secret/key)}}"
+sops_secret: "{{ sops.secret_file(/home/user/secrets/secret_file.yaml).secret_key(['s3']['access_key']) }}"

--- a/himl/simplesops.py
+++ b/himl/simplesops.py
@@ -1,0 +1,126 @@
+# Copyright (c), Edoardo Tenani <e.tenani@arduino.cc>, 2018-2020
+# Simplified BSD License (see LICENSES/BSD-2-Clause.txt or https://opensource.org/licenses/BSD-2-Clause)
+# SPDX-License-Identifier: BSD-2-Clause
+
+from __future__ import absolute_import, division, print_function
+
+import os, logging
+
+from subprocess import Popen, PIPE
+
+logger = logging.getLogger(__name__)
+
+# From https://github.com/getsops/sops/blob/master/cmd/sops/codes/codes.go
+# Should be manually updated
+SOPS_ERROR_CODES = {
+    1: "ErrorGeneric",
+    2: "CouldNotReadInputFile",
+    3: "CouldNotWriteOutputFile",
+    4: "ErrorDumpingTree",
+    5: "ErrorReadingConfig",
+    6: "ErrorInvalidKMSEncryptionContextFormat",
+    7: "ErrorInvalidSetFormat",
+    8: "ErrorConflictingParameters",
+    21: "ErrorEncryptingMac",
+    23: "ErrorEncryptingTree",
+    24: "ErrorDecryptingMac",
+    25: "ErrorDecryptingTree",
+    49: "CannotChangeKeysFromNonExistentFile",
+    51: "MacMismatch",
+    52: "MacNotFound",
+    61: "ConfigFileNotFound",
+    85: "KeyboardInterrupt",
+    91: "InvalidTreePathFormat",
+    100: "NoFileSpecified",
+    128: "CouldNotRetrieveKey",
+    111: "NoEncryptionKeyFound",
+    200: "FileHasNotBeenModified",
+    201: "NoEditorFound",
+    202: "FailedToCompareVersions",
+    203: "FileAlreadyEncrypted",
+}
+
+
+class SopsError(Exception):
+    """Extend Exception class with sops specific information"""
+
+    def __init__(self, filename, exit_code, message, decryption=True):
+        if exit_code in SOPS_ERROR_CODES:
+            exception_name = SOPS_ERROR_CODES[exit_code]
+            message = "error with file %s: %s exited with code %d: %s" % (
+                filename,
+                exception_name,
+                exit_code,
+                message.decode("utf-8"),
+            )
+        else:
+            message = (
+                "could not %s file %s; Unknown sops error code: %s; message: %s"
+                % (
+                    "decrypt" if decryption else "encrypt",
+                    filename,
+                    exit_code,
+                    message.decode("utf-8"),
+                )
+            )
+        super(SopsError, self).__init__(message)
+
+
+class Sops:
+    """Utility class to perform sops CLI actions"""
+
+    @staticmethod
+    def decrypt(
+        encrypted_file,
+        secret_key=None,
+        decode_output=True,
+        rstrip=True,
+    ):
+        command = ["sops"]
+        env = os.environ.copy()
+        if secret_key is None:
+            raise Exception(
+                "Error while getting secret for %s: secret key not supplied"
+                % encrypted_file
+            )
+        command.extend(["--extract", secret_key])
+        command.extend(["--decrypt", encrypted_file])
+        print(command)
+        process = Popen(
+            command,
+            stdin=None,
+            stdout=PIPE,
+            stderr=PIPE,
+            env=env,
+        )
+        (output, err) = process.communicate()
+        exit_code = process.returncode
+
+        if decode_output:
+            # output is binary, we want UTF-8 string
+            output = output.decode("utf-8", errors="surrogate_or_strict")
+            # the process output is the decrypted secret; be cautious
+        if exit_code != 0:
+            raise SopsError(encrypted_file, exit_code, err, decryption=True)
+
+        if rstrip:
+            output = output.rstrip()
+
+        return output
+
+
+class SimpleSops:
+    def __init__(self):
+        pass
+
+    def get(self, secret_file, secret_key):
+        try:
+            logger.info(
+                "Resolving sops secret %s from file %s", secret_key, secret_file
+            )
+            return Sops.decrypt(encrypted_file=secret_file, secret_key=secret_key)
+        except SopsError as e:
+            raise Exception(
+                "Error while trying to read sops value for file %s, key: %s - %s"
+                % (secret_file, secret_key, e)
+            )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ _install_requires = [
 
 setup(
     name='himl',
-    version="0.15.0",
+    version="0.16.0",
     description='A hierarchical config using yaml',
     long_description=_readme + '\n\n',
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Sops secret resolver

this adds [sops](https://github.com/getsops/sops) as an extra secret resolver. I've used most(if not all) of the code from the [sops ansible collection](https://github.com/ansible-collections/community.sops/tree/main) I've left the original license and copyright notices in place.

## Motivation and Context

I'm working on having himl as a data layer for ansible inventory. Using sops as a secret store. It would be great to have this as native usage in sops instead of sprinkling ansible lookups all over.

This might need some more work, but mainly looking here if you're open to making this part of himl?

## How Has This Been Tested?

I've tested this with my own key and encrypted files. To reproduce follow the steps [from sops](https://github.com/getsops/sops/tree/main#test-with-the-dev-pgp-key), and edit the `examples/secrets/default.yaml` to use the example file and fetch a secret.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
