### PR TITLE
Fixing a bug where himl flattens nested lists

### DIFF
--- a/himl/interpolation.py
+++ b/himl/interpolation.py
@@ -100,10 +100,7 @@ class DictIterator(object):
         if isinstance(data, list):
             items = []
             for item in data:
-                if isinstance(item, list):
-                    items.extend(item)
-                else:
-                    items.append(self.loop_all_items(item, process_func))
+                items.append(self.loop_all_items(item, process_func))
             return items
         if isinstance(data, dict):
             for key in data:

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -1,0 +1,37 @@
+# Copyright 2019 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+from pytest import mark
+from himl.interpolation import DictIterator
+
+
+@mark.parametrize(
+    "start, end, func",
+    [
+        (
+            {"test": [1, 3, 2], "another": {"thing": "is", "some": "data"}},
+            {"test": [1, 3, 2], "another": {"thing": "is", "some": "data"}},
+            lambda x: x,
+        ),
+        (
+            {"test": [1, 3, 2], "another": {"thing": "is", "some": "data"}},
+            {"test": [1, 3, 2], "another": {"thing": "isis", "some": "datadata"}},
+            lambda x: 2 * x,
+        ),
+        (
+            [["a", "set"], ["of", "test"], ["data", "for", "testing"], [1, 2, 3]],
+            [["a_", "set_"], ["of_", "test_"], ["data_", "for_", "testing_"], [1, 2, 3]],
+            lambda x: x + "_",
+        ),
+    ],
+)
+def test_dict_iterator(start, end, func):
+    looper = DictIterator()
+    assert looper.loop_all_items(start, func) == end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

In order to fix an issue where `himl` flattens nested lists, the `DictIterator` was modified.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#174 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

If a configuration file should have nested lists, `himl` is no longer compatible. This change allows `himl` to process configuration files structured in this way.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New unit tests were added to verify that the updated `DictIterator` functions as expected.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
