### PR TITLE
Perf improvements

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -46,3 +46,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ COPY pyproject.toml ./
 COPY himl/ ./himl/
 COPY README.md ./
 COPY LICENSE ./
-COPY .git/ ./.git/
+RUN apt-get update && apt-get install -y make curl && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install -y make curl git && rm -rf /var/lib/apt/lists/*
+ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
 
 # Install the package with all optional dependencies for full functionality
 RUN python -m pip install --upgrade pip && pip3 install .[all]

--- a/himl/config_generator.py
+++ b/himl/config_generator.py
@@ -8,6 +8,8 @@
 # OF ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import copy
+import functools
 import json
 import os
 from collections import OrderedDict
@@ -18,13 +20,20 @@ import yaml
 from deepmerge import Merger
 
 from .interpolation import InterpolationResolver, EscapingResolver, InterpolationValidator, SecretResolver, \
-    DictIterator, replace_parent_working_directory, EnvVarResolver
+    DictIterator, replace_parent_working_directory, EnvVarResolver, collect_pending_keys
 from .python_compat import iteritems, primitive_types, PY3
 
 logging.basicConfig()
 logging.root.setLevel(logging.INFO)
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=None)
+def _yaml_get_content_cached(yaml_file):
+    with open(yaml_file, 'r') as f:
+        content = yaml.load(f, Loader=yaml.SafeLoader)
+    return content if content else {}
 
 
 class ConfigProcessor(object):
@@ -45,7 +54,8 @@ class ConfigProcessor(object):
                 allow_unicode=False,
                 type_strategies=[(list, ["append_unique"]), (dict, ["merge"])],
                 fallback_strategies=["override"],
-                type_conflict_strategies=["override"]):
+                type_conflict_strategies=["override"],
+                precomputed_state=None):
 
         # Prepare parameters and create generator
         path = self.get_relative_path(path)
@@ -54,7 +64,8 @@ class ConfigProcessor(object):
         cwd = cwd or os.getcwd()
 
         generator = self._create_and_initialize_generator(
-            cwd, path, multi_line_string, allow_unicode, type_strategies, fallback_strategies, type_conflict_strategies)
+            cwd, path, multi_line_string, allow_unicode, type_strategies, fallback_strategies,
+            type_conflict_strategies, precomputed_state=precomputed_state)
 
         # Process data exclusions and interpolations
         self._process_exclusions(generator, exclude_keys)
@@ -75,12 +86,15 @@ class ConfigProcessor(object):
         return skip_interpolation_validation or skip_interpolations or skip_secrets
 
     def _create_and_initialize_generator(self, cwd, path, multi_line_string, allow_unicode, type_strategies,
-                                         fallback_strategies, type_conflict_strategies):
+                                         fallback_strategies, type_conflict_strategies, precomputed_state=None):
         """Create and initialize the ConfigGenerator."""
         generator = ConfigGenerator(cwd, path, multi_line_string, allow_unicode, type_strategies, fallback_strategies,
                                     type_conflict_strategies)
         generator.generate_hierarchy()
-        generator.process_hierarchy()
+        if precomputed_state is not None:
+            generator.process_hierarchy_with_precomputed(precomputed_state)
+        else:
+            generator.process_hierarchy()
         return generator
 
     def _process_exclusions(self, generator, exclude_keys):
@@ -190,6 +204,7 @@ class ConfigGenerator(object):
         self.type_strategies = type_strategies
         self.fallback_strategies = fallback_strategies
         self.type_conflict_strategies = type_conflict_strategies
+        self._pending_keys = None
         if multi_line_string is True:
             yaml.representer.BaseRepresenter.represent_scalar = ConfigGenerator.custom_represent_scalar  # type: ignore
 
@@ -236,9 +251,7 @@ class ConfigGenerator(object):
 
     @staticmethod
     def yaml_get_content(yaml_file):
-        with open(yaml_file, 'r') as f:
-            content = yaml.load(f, Loader=yaml.SafeLoader)
-        return content if content else {}
+        return copy.deepcopy(_yaml_get_content_cached(yaml_file))
 
     @staticmethod
     def merge_value(reference, new_value, type_strategies, fallback_strategies, type_conflict_strategies):
@@ -329,6 +342,25 @@ class ConfigGenerator(object):
 
         self.generated_data = merged_values
 
+    def process_hierarchy_with_precomputed(self, precomputed_state):
+        full_target_path = os.path.join(self.cwd, self.path)
+        if not os.path.exists(full_target_path):
+            raise FileNotFoundError(f"Path does not exist: {full_target_path}")
+
+        merged_values = copy.deepcopy(precomputed_state)
+        leaf_yaml_files = self.hierarchy[-1] if self.hierarchy else []
+
+        for yaml_file in leaf_yaml_files:
+            yaml_content = self.yaml_get_content(yaml_file)
+            self.merge_yamls(merged_values, yaml_content, self.type_strategies,
+                             self.fallback_strategies, self.type_conflict_strategies)
+            self.resolve_simple_interpolations(merged_values, yaml_file)
+
+        if not merged_values:
+            raise Exception("No YAML files found to process in the hierarchy")
+
+        self.generated_data = merged_values
+
     def get_values_from_dir_path(self):
         values = {}
         full_path = pathlib2.Path(self.path)
@@ -379,18 +411,26 @@ class ConfigGenerator(object):
             remote_states = remote_state_retriever.get_dynamic_data(state_files)
             self.merge_value(self.generated_data, remote_states, self.type_strategies, self.fallback_strategies,
                              self.type_conflict_strategies)
+        self._pending_keys = None
 
     def resolve_interpolations(self):
         resolver = InterpolationResolver()
-        self.generated_data = resolver.resolve_interpolations(self.generated_data)
+        if self._pending_keys is None:
+            self.generated_data = resolver.resolve_interpolations(self.generated_data)
+            self._pending_keys = collect_pending_keys(self.generated_data)
+        elif self._pending_keys:
+            self._pending_keys = resolver.resolve_interpolations(
+                self.generated_data, pending_keys=self._pending_keys)
 
     def resolve_secrets(self, default_aws_profile):
         resolver = SecretResolver()
         self.generated_data = resolver.resolve_secrets(self.generated_data, default_aws_profile)
+        self._pending_keys = None
 
     def resolve_env(self):
         resolver = EnvVarResolver()
         self.generated_data = resolver.resolve_env_vars(self.generated_data)
+        self._pending_keys = None
 
     def validate_interpolations(self):
         self.interpolation_validator.check_all_interpolations_resolved(self.generated_data)

--- a/himl/config_merger.py
+++ b/himl/config_merger.py
@@ -105,6 +105,10 @@ def merge_logic_batch(batch_params):
 def build_parent_cache(directories, cwd=None):
     import copy
     from .config_generator import ConfigGenerator
+    # Patch SafeLoader so !include tags work in yaml_get_content (same patch
+    # that merge_logic applies, but build_parent_cache runs before merge_logic).
+    Loader.add_constructor('!include', Loader.include)
+    yaml.SafeLoader = Loader  # type: ignore
     cwd = cwd or os.getcwd()
     cache = {}
     for leaf_path in directories:

--- a/himl/config_merger.py
+++ b/himl/config_merger.py
@@ -108,7 +108,7 @@ def build_parent_cache(directories, cwd=None):
     # Patch SafeLoader so !include tags work in yaml_get_content (same patch
     # that merge_logic applies, but build_parent_cache runs before merge_logic).
     Loader.add_constructor('!include', Loader.include)
-    yaml.SafeLoader = Loader  # type: ignore
+    yaml.SafeLoader.add_constructor('!include', Loader.include)
     cwd = cwd or os.getcwd()
     cache = {}
     for leaf_path in directories:

--- a/himl/config_merger.py
+++ b/himl/config_merger.py
@@ -89,7 +89,41 @@ class Loader(yaml.SafeLoader):
 Loader.add_constructor('!include', Loader.include)
 
 
-def merge_configs(directories, levels, output_dir, enable_parallel, filter_rules, allow_unicode):
+def _group_by_parent(directories):
+    from collections import defaultdict
+    groups = defaultdict(list)
+    for path in directories:
+        groups[os.path.dirname(path)].append(path)
+    return list(groups.values())
+
+
+def merge_logic_batch(batch_params):
+    for process_params in batch_params:
+        merge_logic(process_params)
+
+
+def build_parent_cache(directories, cwd=None):
+    import copy
+    from .config_generator import ConfigGenerator
+    cwd = cwd or os.getcwd()
+    cache = {}
+    for leaf_path in directories:
+        parent_path = os.path.abspath(os.path.dirname(leaf_path))
+        if parent_path in cache:
+            continue
+        rel_parent = os.path.relpath(parent_path, cwd)
+        gen = ConfigGenerator(cwd, rel_parent, False, False,
+                              [(list, ["append_unique"]), (dict, ["merge"])],
+                              ["override"], ["override"])
+        gen.generate_hierarchy()
+        gen.process_hierarchy()
+        cache[parent_path] = copy.deepcopy(gen.generated_data)
+    logger.info("Pre-computed parent hierarchy for %d unique parent paths", len(cache))
+    return cache
+
+
+def merge_configs(directories, levels, output_dir, enable_parallel, filter_rules, allow_unicode,
+                  enable_precompute=False):
     """
     Method for running the merge configuration logic under different formats
     :param directories: list of paths for leaf directories
@@ -97,16 +131,28 @@ def merge_configs(directories, levels, output_dir, enable_parallel, filter_rules
     :param output_dir: where to save the generated configs
     :param enable_parallel: to enable parallel config generation
     :param allow_unicode: allow unicode characters in output
+    :param enable_precompute: pre-compute merged parent hierarchy before dispatching workers
     """
     config_processor = ConfigProcessor()
+
+    parent_cache = build_parent_cache(directories) if enable_precompute else {}
+
     process_config = []
     for path in directories:
-        process_config.append((config_processor, path, levels, output_dir, filter_rules, allow_unicode))
+        parent_state = parent_cache.get(os.path.abspath(os.path.dirname(path)))
+        process_config.append((config_processor, path, levels, output_dir, filter_rules, allow_unicode, parent_state))
 
     if enable_parallel:
         logger.info("Processing config in parallel")
+        batches = _group_by_parent(directories)
+        batch_params = [
+            [(config_processor, path, levels, output_dir, filter_rules, allow_unicode,
+              parent_cache.get(os.path.abspath(os.path.dirname(path))))
+             for path in batch]
+            for batch in batches
+        ]
         with Pool(cpu_count()) as p:
-            p.map(merge_logic, process_config)
+            p.map(merge_logic_batch, batch_params)
     else:
         for config in process_config:
             merge_logic(config)
@@ -123,6 +169,7 @@ def merge_logic(process_params):
     output_dir = process_params[3]
     filter_rules = process_params[4]
     allow_unicode = process_params[5]
+    precomputed_state = process_params[6] if len(process_params) > 6 else None
 
     # load the !include tag
     Loader.add_constructor('!include', Loader.include)
@@ -133,7 +180,8 @@ def merge_logic(process_params):
     # for path in directories:
     # use the HIML deep merge functionality
     output = dict(
-        config_processor.process(path=path, output_format="yaml", print_data=False, multi_line_string=True))
+        config_processor.process(path=path, output_format="yaml", print_data=False, multi_line_string=True,
+                                 precomputed_state=precomputed_state))
     # exchange the levels to which to run for with the values extracted from the yaml structure
     level_values = [output.get(level) for level in levels]
 
@@ -207,6 +255,8 @@ def get_parser():
                         help='keep these keys from the generated data, based on the configured filter key')
     parser.add_argument('--allow-unicode', dest='allow_unicode', default=False,
                         action='store_true', help='allow unicode characters in output (default: False, outputs escape sequences)')
+    parser.add_argument('--enable-precompute', dest='enable_precompute', default=False,
+                        action='store_true', help='Pre-compute merged parent hierarchy states before parallel processing')
     return parser
 
 
@@ -223,4 +273,5 @@ def run(args=None):
 
     # merge the configs using HIML
     merge_configs(dirs, opts.hierarchy_levels,
-                  opts.output_dir, opts.enable_parallel, opts.filter_rules, opts.allow_unicode)
+                  opts.output_dir, opts.enable_parallel, opts.filter_rules, opts.allow_unicode,
+                  enable_precompute=opts.enable_precompute)

--- a/himl/interpolation.py
+++ b/himl/interpolation.py
@@ -88,7 +88,7 @@ def replace_parent_working_directory(value, cwd):
 
 class InterpolationResolver(object):
 
-    def resolve_interpolations(self, data):
+    def resolve_interpolations(self, data, pending_keys=None):
         # Resolve from dictionary. Do one iteration before secret resolving, in order to resolve interpolations such as
         # the aws.profile
         # Example:
@@ -96,8 +96,9 @@ class InterpolationResolver(object):
         # aws:
         #   profile: "{{my_profile}}"
         from_dict_injector = DictInterpolationResolver(data, FromDictInjector())
+        if pending_keys is not None:
+            return from_dict_injector.resolve_interpolations(data, pending_keys=pending_keys)
         from_dict_injector.resolve_interpolations(data)
-
         return data
 
 
@@ -154,6 +155,55 @@ class DictIterator(object):
                 data[key] = resolved_value
         return data
 
+    def loop_pending_items(self, data, process_func, pending_keys):
+        still_pending = set()
+        for key_path in list(pending_keys):
+            try:
+                node, final_key, value = _get_at_path(data, key_path)
+            except (KeyError, IndexError, TypeError):
+                continue
+            if isinstance(value, string_types):
+                new_value = process_func(value)
+            else:
+                new_value = self.loop_all_items(value, process_func)
+            _set_at_path(data, key_path, new_value)
+            still_pending.update(collect_pending_keys(new_value, key_path))
+        return still_pending
+
+
+def collect_pending_keys(data, prefix=""):
+    pending = set()
+    if isinstance(data, string_types):
+        if is_interpolation(data):
+            pending.add(prefix)
+    elif isinstance(data, list):
+        for i, item in enumerate(data):
+            child = "{}.{}".format(prefix, i) if prefix else str(i)
+            pending.update(collect_pending_keys(item, child))
+    elif isinstance(data, dict):
+        for key, value in iteritems(data):
+            child = "{}.{}".format(prefix, key) if prefix else str(key)
+            pending.update(collect_pending_keys(value, child))
+    return pending
+
+
+def _get_at_path(data, key_path):
+    parts = key_path.split(".")
+    node = data
+    for part in parts[:-1]:
+        node = node[int(part)] if isinstance(node, list) else node[part]
+    final = parts[-1]
+    value = node[int(final)] if isinstance(node, list) else node[final]
+    return node, final, value
+
+
+def _set_at_path(data, key_path, value):
+    node, final, _ = _get_at_path(data, key_path)
+    if isinstance(node, list):
+        node[int(final)] = value
+    else:
+        node[final] = value
+
 
 class AbstractEscapingResolver(DictIterator):
 
@@ -172,7 +222,9 @@ class AbstractEscapingResolver(DictIterator):
 
 class AbstractInterpolationResolver(DictIterator):
 
-    def resolve_interpolations(self, data):
+    def resolve_interpolations(self, data, pending_keys=None):
+        if pending_keys is not None:
+            return self.loop_pending_items(data, self.resolve_interpolation, pending_keys)
         return self.loop_all_items(data, self.resolve_interpolation)
 
     def resolve_interpolation(self, line):

--- a/tests/test_config_generator.py
+++ b/tests/test_config_generator.py
@@ -525,6 +525,24 @@ class TestConfigGenerator:
         with pytest.raises(FileNotFoundError):
             generator.process_hierarchy_with_precomputed(OrderedDict())
 
+    def test_process_hierarchy_with_precomputed_empty_state_raises(self):
+        """process_hierarchy_with_precomputed raises when precomputed state is empty and no leaf YAMLs exist"""
+        empty_leaf = os.path.join(self.temp_dir, 'empty_leaf')
+        os.makedirs(empty_leaf, exist_ok=True)
+
+        generator = ConfigGenerator(
+            cwd=self.temp_dir,
+            path='empty_leaf',
+            multi_line_string=False,
+            allow_unicode=False,
+            type_strategies=[(list, ["append_unique"]), (dict, ["merge"])],
+            fallback_strategies=["override"],
+            type_conflict_strategies=["override"]
+        )
+
+        with pytest.raises(Exception, match="No YAML files found"):
+            generator.process_hierarchy_with_precomputed(OrderedDict())
+
     def test_resolve_interpolations_pending_keys_on_second_pass(self):
         """Second resolve_interpolations call uses targeted pending-key traversal"""
         generator = ConfigGenerator(

--- a/tests/test_config_generator.py
+++ b/tests/test_config_generator.py
@@ -191,6 +191,25 @@ class TestConfigProcessor:
         )
         assert json_result == config_data
 
+    def test_process_with_precomputed_state(self):
+        """ConfigProcessor.process uses precomputed_state via process_hierarchy_with_precomputed"""
+        leaf_dir = os.path.join(self.temp_dir, 'env=dev', 'deployment=dep1')
+        os.makedirs(leaf_dir, exist_ok=True)
+        with open(os.path.join(leaf_dir, 'deployment.yaml'), 'w') as f:
+            yaml.dump({'deployment': 'dep1'}, f)
+
+        precomputed = OrderedDict([('env', 'dev'), ('region', 'us-east-1')])
+        result = self.config_processor.process(
+            cwd=self.temp_dir,
+            path='env=dev/deployment=dep1',
+            skip_interpolation_validation=True,
+            precomputed_state=precomputed,
+        )
+
+        assert result['env'] == 'dev'
+        assert result['region'] == 'us-east-1'
+        assert result['deployment'] == 'dep1'
+
     def test_unicode_processing_disabled(self):
         """Test Unicode processing with allow_unicode=False"""
         config_data = {
@@ -465,6 +484,96 @@ class TestConfigGenerator:
         assert 'naïve' in yaml_output  # Accented characters preserved
         # Emoji might be escaped as \U0001F680 even with allow_unicode=True
         assert ('🚀' in yaml_output or '\\U0001F680' in yaml_output)
+
+    def test_process_hierarchy_with_precomputed(self):
+        """process_hierarchy_with_precomputed merges leaf YAML on top of precomputed state"""
+        leaf_dir = os.path.join(self.temp_dir, 'env=dev', 'deployment=dep1')
+        os.makedirs(leaf_dir, exist_ok=True)
+        with open(os.path.join(leaf_dir, 'deployment.yaml'), 'w') as f:
+            yaml.dump({'deployment': 'dep1', 'replica_count': 3}, f)
+
+        generator = ConfigGenerator(
+            cwd=self.temp_dir,
+            path='env=dev/deployment=dep1',
+            multi_line_string=False,
+            allow_unicode=False,
+            type_strategies=[(list, ["append_unique"]), (dict, ["merge"])],
+            fallback_strategies=["override"],
+            type_conflict_strategies=["override"]
+        )
+
+        precomputed = OrderedDict([('env', 'dev'), ('base_key', 'base_value')])
+        generator.process_hierarchy_with_precomputed(precomputed)
+
+        assert generator.generated_data['env'] == 'dev'
+        assert generator.generated_data['base_key'] == 'base_value'
+        assert generator.generated_data['deployment'] == 'dep1'
+        assert generator.generated_data['replica_count'] == 3
+
+    def test_process_hierarchy_with_precomputed_nonexistent_path(self):
+        """process_hierarchy_with_precomputed raises FileNotFoundError for missing path"""
+        generator = ConfigGenerator(
+            cwd=self.temp_dir,
+            path='nonexistent/path',
+            multi_line_string=False,
+            allow_unicode=False,
+            type_strategies=[(list, ["append_unique"]), (dict, ["merge"])],
+            fallback_strategies=["override"],
+            type_conflict_strategies=["override"]
+        )
+
+        with pytest.raises(FileNotFoundError):
+            generator.process_hierarchy_with_precomputed(OrderedDict())
+
+    def test_resolve_interpolations_pending_keys_on_second_pass(self):
+        """Second resolve_interpolations call uses targeted pending-key traversal"""
+        generator = ConfigGenerator(
+            cwd=self.temp_dir,
+            path='nonexistent',
+            multi_line_string=False,
+            allow_unicode=False,
+            type_strategies=[(list, ["append_unique"]), (dict, ["merge"])],
+            fallback_strategies=["override"],
+            type_conflict_strategies=["override"]
+        )
+        # Two-level chain: 'aval' is a PARTIAL interpolation (not a full {{...}} value),
+        # so FullBlobInjector won't resolve it; it must wait for pass 2 once bval is resolved.
+        # The interpolation regex also requires >=2 chars inside {{}} — hence multi-char keys.
+        generator.generated_data = OrderedDict([
+            ('cval', 'final'),
+            ('bval', '{{cval}}'),
+            ('aval', '{{bval}}-suffix'),
+        ])
+        assert generator._pending_keys is None
+
+        # Pass 1: full traversal — bval resolves, aval stays pending
+        generator.resolve_interpolations()
+        assert generator.generated_data['bval'] == 'final'
+        assert generator.generated_data['aval'] == '{{bval}}-suffix'
+        assert generator._pending_keys == {'aval'}
+
+        # Pass 2: targeted traversal on pending set — aval resolves
+        generator.resolve_interpolations()
+        assert generator.generated_data['aval'] == 'final-suffix'
+        assert generator._pending_keys == set()
+
+    def test_resolve_interpolations_skips_when_pending_empty(self):
+        """resolve_interpolations is a no-op when _pending_keys is an empty set"""
+        generator = ConfigGenerator(
+            cwd=self.temp_dir,
+            path='nonexistent',
+            multi_line_string=False,
+            allow_unicode=False,
+            type_strategies=[(list, ["append_unique"]), (dict, ["merge"])],
+            fallback_strategies=["override"],
+            type_conflict_strategies=["override"]
+        )
+        generator.generated_data = OrderedDict([('key', 'value')])
+        generator._pending_keys = set()  # empty — no interpolations remain
+
+        generator.resolve_interpolations()  # should be a no-op
+        assert generator.generated_data == OrderedDict([('key', 'value')])
+        assert generator._pending_keys == set()
 
     def test_unicode_in_nested_structures(self):
         """Test Unicode handling in nested data structures"""

--- a/tests/test_config_merger.py
+++ b/tests/test_config_merger.py
@@ -17,7 +17,7 @@ from unittest.mock import patch, MagicMock
 
 from himl.config_merger import (
     Loader, merge_configs, merge_logic, get_leaf_directories,
-    get_parser, run
+    get_parser, run, _group_by_parent, merge_logic_batch, build_parent_cache
 )
 
 
@@ -456,3 +456,177 @@ class TestConfigMergerFunctions:
             True,   # allow_unicode=True
             enable_precompute=False
         )
+
+    def test_merge_logic_with_precomputed_state(self):
+        """Test merge_logic passes precomputed_state to ConfigProcessor.process"""
+        self.create_directory_structure()
+
+        mock_processor = MagicMock()
+        mock_processor.process.return_value = {
+            'env': 'dev', 'region': 'us-east-1', 'cluster': 'web'
+        }
+
+        output_dir = os.path.join(self.temp_dir, 'output')
+        os.makedirs(output_dir, exist_ok=True)
+
+        precomputed = {'env': 'dev', 'region': 'us-east-1'}
+        config_tuple = (
+            mock_processor,
+            os.path.join(self.temp_dir, 'env=dev/region=us-east-1/cluster=web'),
+            ['env', 'region', 'cluster'],
+            output_dir,
+            None,
+            False,
+            precomputed,
+        )
+
+        merge_logic(config_tuple)
+
+        call_kwargs = mock_processor.process.call_args[1]
+        assert call_kwargs['precomputed_state'] == precomputed
+
+    @patch('himl.config_merger.build_parent_cache')
+    @patch('himl.config_merger.merge_logic')
+    def test_merge_configs_with_precompute_enabled(self, mock_merge_logic, mock_build_parent_cache):
+        """Test merge_configs calls build_parent_cache when enable_precompute=True"""
+        mock_build_parent_cache.return_value = {}
+        directories = ['dir1', 'dir2']
+
+        merge_configs(directories, ['env'], '/output', enable_parallel=False,
+                      filter_rules=None, allow_unicode=False, enable_precompute=True)
+
+        mock_build_parent_cache.assert_called_once_with(directories)
+        assert mock_merge_logic.call_count == 2
+
+    def test_parser_enable_precompute_flag(self):
+        """Test --enable-precompute flag is parsed correctly"""
+        parser = get_parser()
+
+        args = parser.parse_args([
+            'input_dir', '--output-dir', 'output',
+            '--levels', 'env', '--leaf-directories', 'cluster',
+            '--enable-precompute'
+        ])
+        assert args.enable_precompute is True
+
+    def test_parser_enable_precompute_default_false(self):
+        """Test --enable-precompute defaults to False"""
+        parser = get_parser()
+        args = parser.parse_args([
+            'input_dir', '--output-dir', 'output',
+            '--levels', 'env', '--leaf-directories', 'cluster'
+        ])
+        assert args.enable_precompute is False
+
+
+class TestGroupByParent:
+    """Tests for _group_by_parent helper"""
+
+    def test_single_parent(self):
+        dirs = ['/root/parent/leaf1', '/root/parent/leaf2', '/root/parent/leaf3']
+        result = _group_by_parent(dirs)
+        assert len(result) == 1
+        assert set(result[0]) == set(dirs)
+
+    def test_multiple_parents(self):
+        dirs = [
+            '/root/parent1/leaf1',
+            '/root/parent1/leaf2',
+            '/root/parent2/leaf3',
+        ]
+        result = _group_by_parent(dirs)
+        assert len(result) == 2
+        flat = {d for group in result for d in group}
+        assert flat == set(dirs)
+
+    def test_empty_input(self):
+        assert _group_by_parent([]) == []
+
+    def test_each_leaf_in_own_parent(self):
+        dirs = ['/a/x/leaf', '/b/y/leaf', '/c/z/leaf']
+        result = _group_by_parent(dirs)
+        assert len(result) == 3
+
+
+class TestMergeLogicBatch:
+    """Tests for merge_logic_batch"""
+
+    @patch('himl.config_merger.merge_logic')
+    def test_calls_merge_logic_for_each_param(self, mock_merge_logic):
+        batch = [('p1',), ('p2',), ('p3',)]
+        merge_logic_batch(batch)
+        assert mock_merge_logic.call_count == 3
+        mock_merge_logic.assert_any_call(('p1',))
+        mock_merge_logic.assert_any_call(('p3',))
+
+    @patch('himl.config_merger.merge_logic')
+    def test_empty_batch(self, mock_merge_logic):
+        merge_logic_batch([])
+        mock_merge_logic.assert_not_called()
+
+
+class TestBuildParentCache:
+    """Tests for build_parent_cache"""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _create_service_hierarchy(self, services, deployments_per_service):
+        """Create a minimal hierarchy: cwd/service=X/deployment=Y/deployment.yaml"""
+        for svc in services:
+            svc_dir = os.path.join(self.temp_dir, f'service={svc}')
+            os.makedirs(svc_dir, exist_ok=True)
+            with open(os.path.join(svc_dir, 'service.yaml'), 'w') as f:
+                yaml.dump({'service': svc}, f)
+            for dep in deployments_per_service:
+                dep_dir = os.path.join(svc_dir, f'deployment={dep}')
+                os.makedirs(dep_dir, exist_ok=True)
+                with open(os.path.join(dep_dir, 'deployment.yaml'), 'w') as f:
+                    yaml.dump({'deployment': dep}, f)
+
+    def _leaf_paths(self, services, deployments):
+        return [
+            os.path.join(self.temp_dir, f'service={svc}', f'deployment={dep}')
+            for svc in services for dep in deployments
+        ]
+
+    def test_deduplicates_same_parent(self):
+        """Two leaves under the same service produce one cache entry"""
+        self._create_service_hierarchy(['svc1'], ['dep1', 'dep2'])
+        leaves = self._leaf_paths(['svc1'], ['dep1', 'dep2'])
+
+        cache = build_parent_cache(leaves, cwd=self.temp_dir)
+
+        assert len(cache) == 1
+
+    def test_separate_parents_produce_separate_entries(self):
+        """Leaves under different services produce one entry per service"""
+        self._create_service_hierarchy(['svc1', 'svc2'], ['dep1', 'dep2'])
+        leaves = self._leaf_paths(['svc1', 'svc2'], ['dep1', 'dep2'])
+
+        cache = build_parent_cache(leaves, cwd=self.temp_dir)
+
+        assert len(cache) == 2
+
+    def test_cache_keyed_by_absolute_parent_path(self):
+        """Cache keys are absolute paths of parent directories"""
+        self._create_service_hierarchy(['svc1'], ['dep1'])
+        leaves = self._leaf_paths(['svc1'], ['dep1'])
+
+        cache = build_parent_cache(leaves, cwd=self.temp_dir)
+
+        expected_key = os.path.abspath(os.path.join(self.temp_dir, 'service=svc1'))
+        assert expected_key in cache
+
+    def test_cache_contains_merged_parent_data(self):
+        """Cached state contains YAML data merged from the parent directory"""
+        self._create_service_hierarchy(['svc1'], ['dep1'])
+        leaves = self._leaf_paths(['svc1'], ['dep1'])
+
+        cache = build_parent_cache(leaves, cwd=self.temp_dir)
+
+        parent_key = os.path.abspath(os.path.join(self.temp_dir, 'service=svc1'))
+        assert cache[parent_key].get('service') == 'svc1'

--- a/tests/test_config_merger.py
+++ b/tests/test_config_merger.py
@@ -290,7 +290,8 @@ class TestConfigMergerFunctions:
             'output',
             False,  # enable_parallel default
             None,   # filter_rules_key default
-            False   # allow_unicode default
+            False,  # allow_unicode default
+            enable_precompute=False
         )
 
     def test_parser_default_values(self):
@@ -452,5 +453,6 @@ class TestConfigMergerFunctions:
             'output',
             False,  # enable_parallel default
             None,   # filter_rules_key default
-            True    # allow_unicode=True
+            True,   # allow_unicode=True
+            enable_precompute=False
         )

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -11,10 +11,10 @@
 import pytest
 from himl.interpolation import (
     InterpolationResolver, EscapingResolver, InterpolationValidator,
-    FromDictInjector, FullBlobInjector,
+    FromDictInjector, FullBlobInjector, DictIterator,
     is_interpolation, is_escaped_interpolation, is_full_interpolation,
     is_fully_escaped_interpolation, remove_white_spaces,
-    replace_parent_working_directory
+    replace_parent_working_directory, collect_pending_keys
 )
 
 
@@ -293,3 +293,123 @@ class TestEscapingResolver:
         # The actual escaping logic would be implemented in DictEscapingResolver
         # This test verifies the method can be called without error
         assert result is not None
+
+
+class TestCollectPendingKeys:
+    """Tests for the collect_pending_keys helper"""
+
+    # Note: is_interpolation requires >=2 chars inside {{}} due to the regex
+    # pattern \{\{[^`].*?[^`]\}\} — use multi-char keys like {{env.name}}.
+
+    def test_string_with_interpolation(self):
+        pending = collect_pending_keys('{{env.name}}', 'mykey')
+        assert pending == {'mykey'}
+
+    def test_string_without_interpolation(self):
+        pending = collect_pending_keys('plain_value', 'mykey')
+        assert pending == set()
+
+    def test_dict_with_interpolation(self):
+        data = {'base': 'resolved', 'derived': '{{base_url}}', 'other': 'also_resolved'}
+        pending = collect_pending_keys(data)
+        assert pending == {'derived'}
+
+    def test_list_with_interpolation(self):
+        data = {'items': ['plain', '{{env.name}}', 'also_plain']}
+        pending = collect_pending_keys(data)
+        assert 'items.1' in pending
+        assert 'items.0' not in pending
+        assert 'items.2' not in pending
+
+    def test_nested_dict(self):
+        data = {'outer': {'inner': '{{ref.key}}'}}
+        pending = collect_pending_keys(data)
+        assert 'outer.inner' in pending
+
+    def test_no_interpolations(self):
+        data = {'aa': 'hello', 'bb': 42, 'cc': True}
+        assert collect_pending_keys(data) == set()
+
+    def test_empty_prefix(self):
+        data = {'key': '{{val.x}}'}
+        pending = collect_pending_keys(data)
+        assert 'key' in pending
+
+    def test_list_at_top_level(self):
+        data = ['{{aa.bb}}', 'plain', '{{cc.dd}}']
+        pending = collect_pending_keys(data)
+        assert '0' in pending
+        assert '1' not in pending
+        assert '2' in pending
+
+
+class TestDictIteratorLoopPendingItems:
+    """Tests for DictIterator.loop_pending_items"""
+
+    def test_resolves_pending_key(self):
+        iterator = DictIterator()
+        data = {'env': 'prod', 'url': '{{env}}-api.com'}
+        resolver = InterpolationResolver()
+        pending = {'url'}
+
+        still_pending = iterator.loop_pending_items(
+            data, lambda v: v.replace('{{env}}', 'prod'), pending
+        )
+
+        assert data['url'] == 'prod-api.com'
+        assert 'url' not in still_pending
+
+    def test_skips_missing_key_path(self):
+        """KeyError for a missing path is silently skipped"""
+        iterator = DictIterator()
+        data = {'a': 'hello'}
+        pending = {'nonexistent.path', 'also.missing'}
+
+        result = iterator.loop_pending_items(data, lambda v: v, pending)
+
+        assert isinstance(result, set)
+        assert data == {'a': 'hello'}
+
+    def test_handles_non_string_value_at_path(self):
+        """When the value at a pending path is a dict, loop_all_items is used"""
+        iterator = DictIterator()
+        data = {'a': {'b': '{{c}}'}}
+        pending = {'a'}
+
+        result = iterator.loop_pending_items(data, lambda v: v, pending)
+
+        assert isinstance(result, set)
+
+
+class TestInterpolationResolverWithPendingKeys:
+    """Tests for InterpolationResolver.resolve_interpolations with pending_keys"""
+
+    def test_resolve_with_pending_keys_returns_updated_set(self):
+        resolver = InterpolationResolver()
+        data = {'env': 'prod', 'url': '{{env}}-api.com', 'other': 'static'}
+        pending = {'url'}
+
+        still_pending = resolver.resolve_interpolations(data, pending_keys=pending)
+
+        assert data['url'] == 'prod-api.com'
+        assert isinstance(still_pending, set)
+        assert 'url' not in still_pending
+
+    def test_resolve_with_empty_pending_keys(self):
+        resolver = InterpolationResolver()
+        data = {'env': 'prod', 'url': '{{env}}-api.com'}
+        pending = set()
+
+        still_pending = resolver.resolve_interpolations(data, pending_keys=pending)
+
+        assert still_pending == set()
+        assert data['url'] == '{{env}}-api.com'  # untouched
+
+    def test_resolve_without_pending_keys_returns_data(self):
+        resolver = InterpolationResolver()
+        data = {'env': 'prod', 'url': '{{env}}-api.com'}
+
+        result = resolver.resolve_interpolations(data)
+
+        assert result is data
+        assert data['url'] == 'prod-api.com'

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -380,6 +380,19 @@ class TestDictIteratorLoopPendingItems:
 
         assert isinstance(result, set)
 
+    def test_resolves_list_element_pending_key(self):
+        """_set_at_path uses int indexing when the pending key points to a list element (line 203)"""
+        iterator = DictIterator()
+        data = {'env': 'prod', 'items': ['plain', '{{env.name}}']}
+        pending = {'items.1'}
+
+        still_pending = iterator.loop_pending_items(
+            data, lambda v: v.replace('{{env.name}}', 'prod'), pending
+        )
+
+        assert data['items'][1] == 'prod'
+        assert 'items.1' not in still_pending
+
 
 class TestInterpolationResolverWithPendingKeys:
     """Tests for InterpolationResolver.resolve_interpolations with pending_keys"""


### PR DESCRIPTION
# Description

## 1. YAML Content Cache + Service-Batched Workers

**Files:** `himl/himl/config_generator.py`, `himl/himl/config_merger.py`

**Problem:** `ConfigGenerator.yaml_get_content()` had no caching — every YAML file was read from disk and parsed on every call. With `Pool.map()` dispatching one leaf per worker process, each process independently re-read all parent YAML files (26 root-level files × 921 leaves = ~23,946 redundant reads).

**Solution:**
- Extracted a module-level `_yaml_get_content_cached()` function decorated with `@functools.lru_cache(maxsize=None)`. The public `yaml_get_content()` returns `copy.deepcopy()` of the cached result so in-place merges don't corrupt the cache.
- Changed `merge_configs()` to group leaf directories by their parent directory (`_group_by_parent`) and dispatch one batch per parent to the pool via `merge_logic_batch()`. Workers now process all leaves under the same service directory sequentially, so the lru_cache is exercised across multiple leaves within each worker process.

**Impact:** Parent YAML files are read once per worker batch instead of once per leaf. Combined with Optimization 2, total YAML reads drop from ~31K to ~1,554 (one per unique file).

---

## 2. Pre-Merged Parent Hierarchy Cache

**Files:** `himl/himl/config_generator.py`, `himl/himl/config_merger.py`

**Problem:** Even with batching, each worker's `process_hierarchy()` re-reads and re-merges all parent hierarchy levels (root → env → region → cluster → service) for every leaf. With ~350 unique service-level parents all sharing the same 26 root-level files, those root files are merged 350 times during pre-computation.

**Solution:**
- Added `ConfigGenerator.process_hierarchy_with_precomputed(precomputed_state)`: starts from a pre-merged `OrderedDict` (deep-copied per leaf for isolation) and only processes the leaf-level (`deployment=*`) YAML files.
- Added `build_parent_cache(directories)` in `config_merger.py`: before spawning workers, computes the merged state for each unique parent directory path and stores it in a dict. Workers receive the relevant pre-merged state and skip all parent-level merges.
- Wired through `ConfigProcessor.process(precomputed_state=None)` and `_create_and_initialize_generator()` for a clean, backward-compatible API.
- Enabled via the `--enable-precompute` CLI flag (opt-in).

**Impact:** Eliminates re-merging the parent hierarchy for every leaf. Combined with Optimization 1's cache, total YAML I/O approaches the theoretical minimum of one read per unique file.

---

## 3. Dirty-Value Tracking for Interpolation Resolution

**Files:** `himl/himl/interpolation.py`, `himl/himl/config_generator.py`

**Problem:** `ConfigProcessor.process()` calls `resolve_interpolations()` five times per leaf. Each call invokes `DictIterator.loop_all_items()`, which recursively traverses the entire merged config dict. After pass 1, typically only a small fraction of values (e.g. ~50 out of 10K+ keys) still contain unresolved `{{...}}` patterns — passes 2–5 wastefully visit all already-resolved values.

**Solution:**
- Added `collect_pending_keys(data, prefix="") -> set[str]`: traverses the config dict once and returns the set of dot-notation key-paths whose values still contain `{{...}}`.
- Added `DictIterator.loop_pending_items(data, process_func, pending_keys)`: visits only the key-paths in the pending set and returns the updated set of still-unresolved paths.
- Updated `AbstractInterpolationResolver.resolve_interpolations(data, pending_keys=None)` and `InterpolationResolver.resolve_interpolations(data, pending_keys=None)` to dispatch to `loop_pending_items` when a pending set is provided.
- Added `ConfigGenerator._pending_keys` instance variable. On pass 1 (full traversal), `pending_keys` is populated from the result. Passes 2–5 use targeted traversal on the pending set only. The set is reset to `None` after `add_dynamic_data()`, `resolve_env()`, and `resolve_secrets()` since each may introduce new interpolatable values.

**Impact:** Reduces interpolation traversal complexity from O(all_keys) to O(unresolved_keys) for passes 2–5. Expected 5–10× speedup for the interpolation phase.
## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Performance improvement
- [ ] Test improvement

## Testing

- [x] Tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes manually

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

Add any additional notes, concerns, or context about the changes here.
