### PR TITLE
fix: make Makefile Python path portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# Use Python 3.13 where the packages are installed
-PYTHON := /opt/homebrew/bin/python3.13
+# Allow callers to override the Python executable, defaulting to the active python3.
+PYTHON ?= python3
 
 .PHONY: help install test lint format clean build release bump-patch bump-minor bump-major
 


### PR DESCRIPTION
## Description

  Make the Makefile Python executable portable by replacing the hardcoded `/opt/homebrew/bin/python3.13` path with an overridable
`PYTHON ?= python3` default. This lets contributors use the active `python3` while still allowing explicit overrides such as `make
PYTHON=/path/to/python test`.

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test improvement

  ## Testing

  - [x] Tests pass locally with my changes
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have tested the changes manually

  Tested with:

  - `make -n test`
  - `make PYTHON=/tmp/himl-analysis-venv/bin/python test`

  Result: `197 passed`

  ## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules

  ## Additional Notes

  This change keeps the existing Makefile workflow intact while removing a workstation-specific Python path that fails on other
environments.
